### PR TITLE
Page elements

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -10,5 +10,7 @@ module.exports = defineConfig({
       'cypress/e2e/1-getting-started/*.js',
       'cypress/e2e/2-advanced-examples/*.js',
     ],
+    viewportWidth: 1280,
+    viewportHeight: 720,
   },
 });

--- a/cypress/e2e/auth.cy.js
+++ b/cypress/e2e/auth.cy.js
@@ -1,5 +1,5 @@
 import LoginPage from '../pages/login.page'
-import ProfilePage from '../pages/profile.page'
+import ProfilePage from '../pages/app/profile.page'
 
 describe('Authentication', () => {
   beforeEach(() => {

--- a/cypress/e2e/navigation.cy.js
+++ b/cypress/e2e/navigation.cy.js
@@ -1,0 +1,20 @@
+import MainPage from '../pages/app/main.page'
+
+describe('Navigation', () => {
+  before(() => {
+    cy.login(Cypress.env('TOKEN'), Cypress.env('USER_ID'))
+    cy.reload()
+  })
+
+  it('Courses page opens', () => {
+    MainPage.navbar.linkCourses.click()
+    cy.location('pathname')
+      .should('include', 'course')
+  })
+
+  it('Interview Questions page opens', () => {
+    MainPage.navbar.linkInterviewQuestions.click()
+    cy.location('pathname')
+      .should('include', 'flash')
+  })
+})

--- a/cypress/elements/navbar.js
+++ b/cypress/elements/navbar.js
@@ -1,0 +1,8 @@
+class Navbar {
+  get linkCourses() { return cy.get('[data-qa="topmenu-Courses"]') }
+  get linkInterviewQuestions() { return cy.get('[data-qa="topmenu-Interview Questions"]') }
+  get linkDiary() { return cy.get('[data-qa="topmenu-Diary"]') }
+  get linkChallenges() { return cy.get('[data-qa="topmenu-Challenges"]') }
+}
+
+export default new Navbar()

--- a/cypress/pages/app/app.page.js
+++ b/cypress/pages/app/app.page.js
@@ -1,0 +1,8 @@
+import BasePage from '../base.page'
+import Navbar from '../../elements/navbar'
+
+class AppPage extends BasePage {
+  navbar = Navbar
+}
+
+export default AppPage

--- a/cypress/pages/app/main.page.js
+++ b/cypress/pages/app/main.page.js
@@ -1,0 +1,7 @@
+import AppPage from './app.page'
+
+class MainPage extends AppPage {
+
+}
+
+export default new MainPage()

--- a/cypress/pages/app/profile.page.js
+++ b/cypress/pages/app/profile.page.js
@@ -1,6 +1,6 @@
-import BasePage from './base.page'
+import AppPage from './app.page'
 
-class ProfilePage extends BasePage {
+class ProfilePage extends AppPage {
   get iconAvatar() { return cy.get('.ant-avatar-square') }
 }
 


### PR DESCRIPTION
The largest architecture change here is that pages that are not related to authentication are now using `AppPage` class (not `BasePage`) as a parent class.

**Application** pages (except **authentication** pages) have navigation bar in common, so we don't want this element to be in `BasePage` class.

Added:
- `Navbar` page element
- `AppPage` page object
- `MainPage` page object
- `Navigation` spec

Also updated page imports.